### PR TITLE
[libresourceqt] Fix unit tests. Fixes JB#52805

### DIFF
--- a/tests/test-resource-set/test-resource-set.cpp
+++ b/tests/test-resource-set/test-resource-set.cpp
@@ -56,7 +56,10 @@ Resource * TestResourceSet::resourceFromType(ResourceType type)
         return new LensCoverResource;
     case HeadsetButtonsType:
         return new HeadsetButtonsResource;
+    case RearFlashlightType:
+        return new RearFlashlightResource;
     default:
+        qWarning() << "Unhandled resource type mapping" << type;
         return NULL;
     }
 }
@@ -64,19 +67,6 @@ Resource * TestResourceSet::resourceFromType(ResourceType type)
 using namespace ResourcePolicy;
 
 TestResourceSet::TestResourceSet()
-    : audioResource(NULL)
-    , audioRecorderResource(NULL)
-    , videoResource(NULL)
-    , videoRecorderResource(NULL)
-    , vibraResource(NULL)
-    , ledsResource(NULL)
-    , backlightResource(NULL)
-    , systemButtonResource(NULL)
-    , lockButtonResource(NULL)
-    , scaleButtonResource(NULL)
-    , snapButtonResource(NULL)
-    , lensCoverResource(NULL)
-    , headsetButtonsResource(NULL)
 {
 }
 

--- a/tests/test-resource-set/test-resource-set.h
+++ b/tests/test-resource-set/test-resource-set.h
@@ -31,21 +31,6 @@ class TestResourceSet: public QObject
 {
     Q_OBJECT
 private:
-
-    ResourcePolicy::AudioResource *audioResource;
-    ResourcePolicy::AudioRecorderResource *audioRecorderResource;
-    ResourcePolicy::Resource *videoResource;
-    ResourcePolicy::Resource *videoRecorderResource;
-    ResourcePolicy::Resource *vibraResource;
-    ResourcePolicy::Resource *ledsResource;
-    ResourcePolicy::Resource *backlightResource;
-    ResourcePolicy::Resource *systemButtonResource;
-    ResourcePolicy::Resource *lockButtonResource;
-    ResourcePolicy::Resource *scaleButtonResource;
-    ResourcePolicy::Resource *snapButtonResource;
-    ResourcePolicy::Resource *lensCoverResource;
-    ResourcePolicy::Resource *headsetButtonsResource;
-
     ResourcePolicy::Resource * resourceFromType(ResourcePolicy::ResourceType type);
 
     void waitForSignal(const QObject *sender, const char *signal, quint32 timeout = 1000);

--- a/tests/test-resource/test-resource.cpp
+++ b/tests/test-resource/test-resource.cpp
@@ -56,7 +56,10 @@ Resource * TestResource::resourceFromType(ResourceType type)
         return lensCoverResource;
     case HeadsetButtonsType:
         return headsetButtonsResource;
+    case RearFlashlightType:
+        return rearFlashlightResource;
     default:
+        qWarning() << "Unhandled resource type mapping" << type;
         return NULL;
     }
 }
@@ -90,6 +93,8 @@ const char * TestResource::stringFromType(ResourceType type)
         return "LensCoverType";
     case HeadsetButtonsType:
         return "HeadsetButtonsType";
+    case RearFlashlightType:
+        return "RearFlashlightType";
     default:
         qDebug("Unknown Type 0x%02x requested", type);
         return NULL;
@@ -110,6 +115,7 @@ TestResource::TestResource()
     , snapButtonResource(NULL)
     , lensCoverResource(NULL)
     , headsetButtonsResource(NULL)
+    , rearFlashlightResource(NULL)
 {
 }
 
@@ -132,6 +138,7 @@ void TestResource::init()
     snapButtonResource = new SnapButtonResource;
     lensCoverResource = new LensCoverResource;
     headsetButtonsResource = new HeadsetButtonsResource;
+    rearFlashlightResource = new RearFlashlightResource;
 }
 
 void TestResource::cleanup()
@@ -149,6 +156,7 @@ void TestResource::cleanup()
     delete snapButtonResource;
     delete lensCoverResource;
     delete headsetButtonsResource;
+    delete rearFlashlightResource;
 }
 
 void TestResource::testDefaults()
@@ -157,6 +165,7 @@ void TestResource::testDefaults()
         ResourceType expected = (ResourceType)type;
         Resource *resource = resourceFromType(expected);
 
+        QVERIFY(resource);
         QVERIFY(!resource->isGranted());
         QVERIFY(!resource->isOptional());
     }
@@ -167,6 +176,7 @@ void TestResource::testType()
     for (quint32 type = AudioPlaybackType; type < NumberOfTypes; type++) {
         ResourceType expected = (ResourceType)type;
         Resource *resource = resourceFromType(expected);
+        QVERIFY(resource);
         if (resource->type() != expected) {
             qDebug("expected ResourceType = %s, got %s",
                    stringFromType(expected), stringFromType(resource->type()));
@@ -216,6 +226,7 @@ void TestResource::testOptional()
     QFETCH(bool, expected);
 
     Resource *resource = resourceFromType(type);
+    QVERIFY(resource);
 
     resource->setOptional(optional);
     bool result = resource->isOptional();

--- a/tests/test-resource/test-resource.h
+++ b/tests/test-resource/test-resource.h
@@ -51,6 +51,7 @@ private:
     Resource *snapButtonResource;
     Resource *lensCoverResource;
     Resource *headsetButtonsResource;
+    Resource *rearFlashlightResource;
 
     Resource * resourceFromType(ResourceType type);
     const char * stringFromType(ResourceType type);


### PR DESCRIPTION
Commit af8c65d4 added rear flash resource without adapting the tests,
and the tests didn't have any protection on unhandled resource type.

Deleted some unused member variables from test-resource-set too.

@Tomin1 @spiiroin 